### PR TITLE
Add dotenv-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Ignore any .env secrets
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :assets do
 end
 
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'rspec-rails', '~> 2.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,9 @@ GEM
       execjs
     coffee-script-source (1.6.2)
     diff-lcs (1.2.4)
+    dotenv (0.8.0)
+    dotenv-rails (0.8.0)
+      dotenv (= 0.8.0)
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
@@ -140,6 +143,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails (~> 3.2.1)
+  dotenv-rails
   foursquare2
   haml
   jquery-rails


### PR DESCRIPTION
[Dotenv](https://github.com/bkeepers/dotenv) loads environment variables from `.env` into `ENV`, making it a lot easier to launch things like the rails console, etc with all of your various API keys in tact.

This generally suites my development workflow, but I won't take offense if you don't want to bring another library into your app ;-)
